### PR TITLE
Bugfix: Mask sign extended bits

### DIFF
--- a/i2c.go
+++ b/i2c.go
@@ -175,7 +175,7 @@ func (v *I2C) ReadRegS16LE(reg byte) (int16, error) {
 		return 0, err
 	}
 	// exchange bytes
-	w = (w&0xFF)<<8 + w>>8
+	w = (w&0xFF)<<8 + (w>>8) & 0xFF
 	return w, nil
 
 }


### PR DESCRIPTION
at line 178:

```
w = (w&0xFF)<<8 + w>>8
```

If (w & (1<<7)) == 1, (w>>8) is sign extended and bigger than 0xff,  then the result goes wrong.
So repace (w>>8) with (w>>8) & 0xFF. 
