### PR TITLE
Add cgo/non-cgo compile modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library written in [Go programming language](https://golang.org/) intended 
 Compatibility
 -------------
 
-Tested on Raspberry PI 1 (model B) and Banana PI (model M1).
+Tested on Raspberry Pi 1 (model B), Raspberry Pi 3 B+, Banana Pi (model M1), Orange Pi Zero, Orange Pi One.
 
 Golang usage
 ------------
@@ -45,6 +45,7 @@ logger.ChangePackageLogLevel("i2c", logger.InfoLevel)
 Once you put this call, it will decrease verbosity from default "Debug" up to next "Info" level, reducing the number of low-level console outputs that occur during interaction with the I2C bus. Please, find examples in corresponding I2C-driven sensors among my projects.
 
 You will find here the list of all devices and sensors supported by me, that reference this library:
+
 - [Liquid-crystal display driven by Hitachi HD44780 IC](https://github.com/d2r2/go-hd44780).
 - [BMP180/BMP280/BME280 temperature and pressure sensors](https://github.com/d2r2/go-bsbmp).
 - [DHT12/AM2320 humidity and temperature sensors](https://github.com/d2r2/go-aosong).

--- a/cgo.go
+++ b/cgo.go
@@ -1,0 +1,12 @@
+// +build linux,cgo
+
+package i2c
+
+// #include <linux/i2c-dev.h>
+import "C"
+
+// Get I2C_SLAVE constant value from
+// Linux OS I2C declaration file.
+const (
+	I2C_SLAVE = C.I2C_SLAVE
+)

--- a/i2c.go
+++ b/i2c.go
@@ -1,11 +1,12 @@
-// Package i2c provides low level control over the linux i2c bus.
+// Package i2c provides low level control over the Linux i2c bus.
 //
 // Before usage you should load the i2c-dev kernel module
 //
 //      sudo modprobe i2c-dev
 //
 // Each i2c bus can address 127 independent i2c devices, and most
-// linux systems contain several buses.
+// Linux systems contain several buses.
+
 package i2c
 
 import (
@@ -13,10 +14,6 @@ import (
 	"fmt"
 	"os"
 	"syscall"
-)
-
-const (
-	I2C_SLAVE = 0x0703
 )
 
 // I2C represents a connection to I2C-device.
@@ -48,7 +45,7 @@ func (v *I2C) GetBus() int {
 	return v.bus
 }
 
-// GetBus return device occupied address in the bus.
+// GetAddr return device occupied address in the bus.
 func (v *I2C) GetAddr() uint8 {
 	return v.addr
 }
@@ -57,8 +54,8 @@ func (v *I2C) write(buf []byte) (int, error) {
 	return v.rc.Write(buf)
 }
 
-// Write sends bytes to the remote I2C-device. The interpretation of
-// the message is implementation-dependant.
+// WriteBytes send bytes to the remote I2C-device. The interpretation of
+// the message is implementation-dependent.
 func (v *I2C) WriteBytes(buf []byte) (int, error) {
 	lg.Debugf("Write %d hex bytes: [%+v]", len(buf), hex.EncodeToString(buf))
 	return v.write(buf)
@@ -68,7 +65,7 @@ func (v *I2C) read(buf []byte) (int, error) {
 	return v.rc.Read(buf)
 }
 
-// ReadBytes reads bytes from I2C-device.
+// ReadBytes read bytes from I2C-device.
 // Number of bytes read correspond to buf parameter length.
 func (v *I2C) ReadBytes(buf []byte) (int, error) {
 	n, err := v.read(buf)

--- a/logger.go
+++ b/logger.go
@@ -3,7 +3,8 @@ package i2c
 import logger "github.com/d2r2/go-logger"
 
 // You can manage verbosity of log output
-// in the package by changing last parameter value.
+// in the package by changing last parameter value
+// (comment/uncomment corresponding lines).
 var lg = logger.NewPackageLogger("i2c",
 	logger.DebugLevel,
 	// logger.InfoLevel,

--- a/noncgo.go
+++ b/noncgo.go
@@ -1,0 +1,11 @@
+// +build !cgo
+
+package i2c
+
+// Use hard-coded value for system I2C_SLAVE
+// constant, if OS not Linux or CGO disabled.
+// This is not a good approach, but
+// can be used as a last resort.
+const (
+	I2C_SLAVE = 0x0703
+)


### PR DESCRIPTION
Use Golang [build constraint](https://golang.org/pkg/go/build/#hdr-Build_Constraints) to more precisely bind I2C to Linux OS system settings.